### PR TITLE
Bootstrap4 gallery (#55)

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,15 +1,33 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1">
+	    <!-- Required meta tags always come first -->
+	    <meta charset="utf-8">
+	    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	    <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+	    <!-- Bootstrap CSS -->
+	    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+
 		<title>OpenHouse - Detailed property info</title>
+		
+		<!-- Mapping CSS -->
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/leaflet.css" />
-		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.6/cosmo/bootstrap.min.css" type="text/css" rel="stylesheet"/>
-	    <link rel="stylesheet" type="text/css" href="style.css">
+	    
+	    <link rel="stylesheet" type="text/css" href="style.css">	    
 	</head>
 	<body>
 		<div id="outer"></div>
+		
+
+	    <!-- jQuery first, then Tether, then Bootstrap JS. -->
+	    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
+	    <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
+	    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+
+	    <!-- k-d Tree Structures -->
 		<script src="scripts/kdTree-min.js"></script>
 		<script src="js/scripts.min.js"></script>
+	
 	</body>
 </html>

--- a/js/components/Controls.js
+++ b/js/components/Controls.js
@@ -33,44 +33,74 @@ export default class Controls extends React.Component {
     var loadingMessage = <p>Loading...</p>
     if (this.props.busy || this.props.changed) {
       if (this.props.offset == 0 && this.props.count == 1) {
-        loadingMessage = <p>Looking in this area...</p>
+        loadingMessage = <div class="alert alert-info" role="alert">
+                            <strong>Hang fire a second!</strong> Were looking for properties in this area.
+                            <img src="box.gif" class="float-xs-right" alt="Loading image" width="40"/>
+                          </div>
       }
       else {
-        loadingMessage = <p>Checking for more listings...</p>
+        loadingMessage = <div class="alert alert-info" role="alert">
+                            <strong>Hang fire a second!</strong> Were checking for more listings...
+                            <img src="box.gif" class="float-xs-right" alt="Loading image" width="40"/>
+                          </div>
       }
     } else {
       if (this.props.count > 0) {
         var ratio = 1.0 * this.props.offset / this.props.count
-        loadingMessage = <p>Sample size shown: {parseInt(ratio*100).toString()}%</p>
+        loadingMessage = <div class="alert alert-success" role="alert">
+                            <strong>Found some properties!</strong> Sample size shown: {parseInt(ratio*100).toString()}% 
+                          </div>
       } else {
-        loadingMessage = <p>No records found.</p>
+        loadingMessage = <div class="alert alert-danger alert-dismissible" role="alert">
+                          <strong>Oh crumbs!</strong> We didnt find any properties. Try changing the filters above.
+                          </div>
       }
     }
-    return (<div id="controls" class="row">
-              <div class="col-sm-3">
-          			<Slider title='Beds' min_value={0} max_value={10} low={this.props.searchCriteria.bedrooms[0]} high={this.props.searchCriteria.bedrooms[1]} onUpdate={this.onUpdate.bind(this, 'bedrooms')} />
-          			<Slider title='Bath' min_value={0} max_value={10} low={this.props.searchCriteria.bathrooms[0]} high={this.props.searchCriteria.bathrooms[1]} onUpdate={this.onUpdate.bind(this, 'bathrooms')} />
-              </div>
-              <div class="col-sm-3">
-          			<Slider title='Price' min_value={0} max_value={10000000} low={this.props.searchCriteria.price[0]} high={this.props.searchCriteria.price[1]} onUpdate={this.onUpdate.bind(this, 'price')} />
-          			<Slider title='sq.ft.' min_value={0} max_value={10000} low={this.props.searchCriteria.sqft[0]} high={this.props.searchCriteria.sqft[1]} onUpdate={this.onUpdate.bind(this, 'sqft')} />
-              </div>
-              <div class="col-sm-6">
-              {this.props.network_ok ? "": "Network issues!"}
-                {loadingMessage}
-                {this.props.busy | this.props.changed ? <img src="box.gif" width="60" />: ""}
-                <div id='curlBox'>
-                  <span class="ui_label">cURL request: </span>
-                  <input class='curl' value={this.state.value} onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
+    return (
+<div>
+  <div id="filters" class="container">
+      <h3>Filters</h3>
+      <div class="row">
+        <div class="col-sm-4">
+          <p>Number of bedrooms</p>
+          <Slider title='Beds' min_value={0} max_value={10} low={this.props.searchCriteria.bedrooms[0]} high={this.props.searchCriteria.bedrooms[1]} onUpdate={this.onUpdate.bind(this, 'bedrooms')} />
+          <p>Number of bathrooms</p>
+          <Slider title='Bath' min_value={0} max_value={10} low={this.props.searchCriteria.bathrooms[0]} high={this.props.searchCriteria.bathrooms[1]} onUpdate={this.onUpdate.bind(this, 'bathrooms')} />
+        </div>
 
-                  <CopyToClipboard text={this.state.value}
-                    onCopy={() => this.setState({copied: true})}>
-                    <button><img src="copy.png" id='copyPng' alt="Copy to clipboard" /></button>
-                  </CopyToClipboard>&nbsp;
-
-                  {this.state.copied ? <span style={{color: 'red'}}>Copied.</span> : null}
-                </div>
+        <div class="col-sm-4">
+          <p>Price</p>
+          <Slider title='Price' min_value={0} max_value={10000000} low={this.props.searchCriteria.price[0]} high={this.props.searchCriteria.price[1]} onUpdate={this.onUpdate.bind(this, 'price')} />
+          <p>Area (Sq.Ft)</p>
+          <Slider title='sq.ft.' min_value={0} max_value={10000} low={this.props.searchCriteria.sqft[0]} high={this.props.searchCriteria.sqft[1]} onUpdate={this.onUpdate.bind(this, 'sqft')} />
+        </div>
+      </div>
+      
+      <div class="row">
+        <form class="form">
+          <div class="form-group">
+            <label for="cURL_textbox">cURL Request: </label>
+            <div class="input-group">
+              <input type="text" class="form-control" id="cURL_textbox" value={this.state.value} onChange={({target: {value}}) => this.setState({value, copied: false})}/>
+              <div class="input-group-addon">
+              <CopyToClipboard text={this.state.value} onCopy={() => this.setState({copied: true})}>
+              <buton>Copy <img src="copy.png" id='copyPng' alt="Copy to clipboard" /></buton>
+                </CopyToClipboard>
               </div>
-         </div>)
+            </div>
+          </div>
+          {this.state.copied ? <span style={{color: 'red'}}> Copied.</span> : null}
+        </form>
+      </div>
+
+      <div class="row">
+        {this.props.network_ok ? "" : <div class="alert alert-danger alert-dismissible" role="alert">
+                                      <strong>Houston we have a problem!</strong> Cannot connect to Open House Project API.
+                                    </div>}
+        {loadingMessage}
+      </div>
+    </div>
+</div>
+   )
   }
 }

--- a/js/components/DataTable.js
+++ b/js/components/DataTable.js
@@ -46,10 +46,7 @@ export default class DataTable extends React.Component {
 
     var columns = [
         {key: 'listing_timestamp', label: 'Timestamp'},
-        {key: 'listing_type', label: 'Type', cell: function( item, columnKey ) {
-          // TODO: use this template to make the columns more interesting
-          return <span style={{color: 'black'}}>{item.listing_type}</span>
-        }},
+        {key: 'listing_type', label: 'Type'},
         {key: 'price', label: 'Price'},
         {key: 'bedrooms', label: 'Bedrooms'},
         {key: 'bathrooms', label: 'Bathrooms'},
@@ -58,6 +55,7 @@ export default class DataTable extends React.Component {
     ]
 
     return <JsonTable
+      className={ "table table-striped table-hover table-sm" }
       rows={ listings }
       columns={ columns }
       settings={ this.getSettings() }

--- a/js/components/DataView.js
+++ b/js/components/DataView.js
@@ -20,29 +20,25 @@ export default class DataView extends React.Component {
 			}
 			else {
 				plotArea = (
-					<div class="col-md-6">
-						<div id="rowOneRight">
 							<Plots listings={this.props.listings} />
-						</div>
-					</div>
 				)
 			}
 		}
 		return (
-    		<div id="tabs">
-    			<div id="rowOne">
-    				<div id="rowOneLeft">
-    					<OpenHouseMap listings={this.props.listings} position={this.props.position} zoom={this.props.zoom} setPositionAndZoom={this.props.setPositionAndZoom} />
-    				</div>
-    				<div id="rowOneRight">
-    					{plotArea}
+				<div class="container">
+					<div id="mapAndPlotRow" class="row clearfix">
+						<div class="col-md-5 float-xs-left">
+							<OpenHouseMap listings={this.props.listings} position={this.props.position} zoom={this.props.zoom} setPositionAndZoom={this.props.setPositionAndZoom} />    				
+						</div>		
+
+						<div class="col-md-5 float-xs-right">
+							{plotArea}
+						</div>
 					</div>
-    			</div>
-				<div class="clear"></div>
-    			<div>
-	    			<DataTable listings={this.props.listings} />
-    			</div>
-           </div>
+					<div class="row">
+						<DataTable listings={this.props.listings} />
+					</div>
+				</div>
 		)
 	}
 }

--- a/js/components/Footer.js
+++ b/js/components/Footer.js
@@ -4,9 +4,11 @@ import ReactDOM from "react-dom";
 export default class Footer extends React.Component {
 
   render() {
-    return (<div>
-    		<hr/>
-    		<a href="http://www.gnu.org/licenses/gpl-3.0.txt"><img class="gnu-img" src="/img/gnu-gpl-3.png" /></a>
-           </div>)
+    return (<div class="container">
+    			<div class="text-xs-center">
+  					<img src="..." class="rounded gnu-img" alt="GNU Logo" src="/img/gnu-gpl-3.png" href="http://www.gnu.org/licenses/gpl-3.0.txt"/>
+				</div>
+           	</div>
+           )
   }
 }

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -4,16 +4,15 @@ import ReactDOM from "react-dom";
 export default class Header extends React.Component {
 
 	render() {
-		return (<div id="header">
-					<div id="logo">
-					<img id="logo-img" src="/img/dshs.png" />
-					</div>
-					<div id="title">OpenHouse Project (alpha release)</div>
-					<div class="tooltip">
-						<img id="info-img" src="/img/info.png" />
-						<span class="tooltiptext">Tooltip text</span>
-					</div>
-				</div>
+		return (
+<div id="header">
+	<nav class="navbar navbar-dark bg-inverse">
+		<a class="navbar-brand" href="#">
+			<img src="/img/dshs.png" width="30" height="30" alt="OpenHouse Project Logo" />
+			OpenHouse Project (Alpha Release)
+		</a>
+	</nav>
+</div>
 		)
 	}
 }

--- a/js/components/PlotsNone.js
+++ b/js/components/PlotsNone.js
@@ -53,40 +53,42 @@ export default class PlotsNone extends Component {
 		}
 				  
 		return (
-			<div class="plots-empty">
-				<span class="plots-empty-title">No properties found</span>
-				<p>OpenHouse does not yet have any property sales data for this area.
-				We're a developing project.  If you know where we might pull from, please
-				let us know in the box below.</p>
-
-				<div id="urlbox">
-				 <span class="plots-empty-title2">Tell us about a website</span>
-
-				  <table>
-				    <tbody>
-					    <tr>
-					      <td>URL:</td>
-					      <td><input id="url" class="box" type="text" value="http://" /></td>
-					    </tr>
-					    <tr>
-					      <td>Email:</td>
-					      <td><input id="email" class="box" type="text" value="" /></td>
-					    </tr>
-					    <tr>
-					      <td></td>
-					      <td><input type="checkbox" id="cb_notify" checked />Notify me about updates related to this data</td>
-					    </tr>
-					    <tr>
-					      <td></td>
-					      <td align="right">
-					      	<button id="btnSubmit" onClick={this.onSubmit.bind(this)}>Submit</button>
-					      </td>
-					    </tr>
-					</tbody>
-				  </table>
-				  {result}
+				<div class="row">
+					<h4>No properties found!</h4>
+					<p>
+						OpenHouse does not yet have any property sales data for this area.
+						We're a developing project.  <strong>If you know where we might pull from, please
+						let us know in the box below.</strong>
+					</p>
+				    <div class="form-group row">
+				      <label for="email" class="col-sm-2 col-form-label">Email</label>
+				      <div class="col-sm-10">
+				        <input type="email" class="form-control" id="email" placeholder="Email" />
+				      </div>
+				    </div>
+				    <div class="form-group row">
+				      <label for="url" class="col-sm-2 col-form-label">URL</label>
+				      <div class="col-sm-10">
+				        <input type="text" class="form-control" id="url" placeholder="https://" />
+				      </div>
+				    </div>
+				    <div class="form-group row">
+				      <label class="col-sm-2"></label>
+				      <div class="col-sm-10">
+				        <div class="form-check">
+				          <label class="form-check-label">
+				            <input class="form-check-input" type="checkbox" id="cb_notify" checked /> Notify me about updates related to this data
+				          </label>
+				        </div>
+				      </div>
+				    </div>
+				    <div class="form-group row">
+				      <div class="offset-sm-2 col-sm-10">
+				        <button type="submit" class="btn btn-primary" onClick={this.onSubmit.bind(this)}>Submit</button>
+				      </div>
+				      {result}
+				    </div>
 				</div>
-			</div>
     	)
 	}
 }

--- a/js/components/Slider.js
+++ b/js/components/Slider.js
@@ -54,10 +54,11 @@ export default class Slider extends React.Component {
 				   allowCross={false}
 				   range={true}
 				   defaultValue={defVal}
+				   tipFormatter={null}
 				   onChange={this.onPartialUpdate.bind(this)}
 				   onAfterChange={this.onUpdate.bind(this)}
 				  />
-      		<center><span class='slider_label'>{this.props.title}: {low_label} to {high_label}</span></center>
+      		<p class="text-xs-center slider_label">{low_label} to {high_label}</p>
            </div>)
 	}
 }

--- a/slider.htm
+++ b/slider.htm
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
    <head>
     <link rel="stylesheet" type="text/css" href="style.css">
     <script src="http://d3js.org/d3.v3.min.js"></script>
@@ -30,4 +31,3 @@
    </script>
    </body>
 </html>
-

--- a/style.css
+++ b/style.css
@@ -70,19 +70,17 @@ body {
   font-weight: bold;
 }
 
+#mapAndPlotRow {
+  padding-right: 5em;*/
+}
+
 #rowOneLeft {
 }
 
-.col-sm-6 {
-  overflow: hidden;
-  height: 90px;
+#filters {
+  padding: 1.5rem;
 }
 
-.col-md-6 {
-  margin-left: 400px;
-  min-width: 300px;
-  width: 50%;
-}
 
 #rowOne {
   display: flex;
@@ -95,9 +93,6 @@ body {
   flex-flow: row wrap;
 }
 
-.btn {
-    height: 15px;
-}
 
 #btnCopy {
     width: 25px;
@@ -127,10 +122,6 @@ body {
   height: 300px;
   margin-bottom: 5px;
   flex-flow: row wrap;
-}
-
-.btn {
-    height: 15px;
 }
 
 #btnCopy {
@@ -150,7 +141,7 @@ body {
 /*********************************************************
   DATA TABLE
 **********************************************************/
-
+/*
 .jsonTable {
 }
 
@@ -176,7 +167,7 @@ body {
 .jsonEven {
   background-color: #efefef;
 }
-
+*/
 /*********************************************************
   MAP
 **********************************************************/
@@ -185,20 +176,9 @@ body {
   font-weight: bold;
 }
 
-#map1 {
-  position: absolute;
-  height: 300px;
-  width: 400px;
-}
-
 .the-map {
-  position: absolute;
   height: 300px;
   width: 400px;
-}
-
-.leaflet-container {
-  position: absolute;
 }
 
 /*********************************************************
@@ -216,7 +196,6 @@ body {
   width: 400px;
   height: 300px;
   padding: 10px;
-  margin-left: 405px;
 }
 
 .Plots {
@@ -257,7 +236,7 @@ body {
 .slider {
   margin-bottom: 5px;
   margin-left: 10px;
-  width: 175px;
+  width: 200px;
   height: 40px;
 }
 .slider_vals {
@@ -277,6 +256,7 @@ body {
 
 
 .rc-slider {
+  margin-bottom: .5rem;
   position: relative;
   height: 4px;
   width: 100%;


### PR DESCRIPTION
* Swap out bootstrap 3 for 4

* Assign HTML5 doctype

* Bootstrap 4 index. Add some comments

* Change to branded nav bar

* Push the helper text to clear the slider marks

* Stop the redundant tool tip being generated and take the title out of the text

* Add a little spacing to the filters div

* Make sliders wider

* Switch updating messages to use bootstrap alerts

* Reorder the controls section into a new filters div

* Change network issues message to be alert also

* Fix for accidentally committing the test of the network alert

* Change the look of the copy cURL text box

* Simplify the map + chart layout a little by removing conflicting css

* Bootstrap the table

* No longer need the margin to push the plots empty across due to bootstrapping

* Bootstrap the form for more data

* Remove redundant css classes

* Centre the GNU footer

* Remove the inline, seems to be stopping the text box from extending across the screen. Will need to investigate further to see if there is a better alternative to setting the length manually.

* Remove table formatting to revert to bootstrap look and feel table. It’s setup for a bordered, striped table with hover highlighting.

* Remove the table-bordered. Discovered that we can’t apply the thead-inverse class from Bootstrap cleanly as the JSONTable react lib applies the header class to each cell rather than the thead tag.